### PR TITLE
Add PHP document management skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# WEBII
+# Sistema de Gestión Documental
+
+Este proyecto es un ejemplo básico de una aplicación web de gestión documental desarrollada en PHP con Bootstrap y MySQL.
+
+## Estructura del proyecto
+
+- **src/**: Contiene los archivos PHP de la aplicación.
+- **sql/db_schema.sql**: Script para crear la estructura de la base de datos en MySQL.
+
+## Requisitos
+
+- PHP 8 o superior con la extensión PDO para MySQL.
+- Servidor web compatible (Apache, Nginx, etc.).
+- MySQL 5.7 o superior.
+
+## Instalación
+
+1. Crear la base de datos y las tablas ejecutando el script `sql/db_schema.sql`.
+2. Configurar los datos de conexión en `src/config.php` (usuario, contraseña y nombre de la base de datos).
+3. Colocar el contenido de la carpeta `src` en el directorio público de su servidor web.
+4. Acceder a `index.php` desde el navegador.
+
+Este ejemplo solo muestra la lectura de departamentos y documentos. Se pueden agregar funcionalidades adicionales como autenticación, carga de archivos y gestión de roles.

--- a/sql/db_schema.sql
+++ b/sql/db_schema.sql
@@ -1,0 +1,33 @@
+CREATE DATABASE IF NOT EXISTS doc_management CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE doc_management;
+
+CREATE TABLE roles (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(50) NOT NULL
+);
+
+CREATE TABLE departments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    role_id INT,
+    department_id INT,
+    FOREIGN KEY (role_id) REFERENCES roles(id),
+    FOREIGN KEY (department_id) REFERENCES departments(id)
+);
+
+CREATE TABLE documents (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    filename VARCHAR(255) NOT NULL,
+    department_id INT NOT NULL,
+    uploaded_by INT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (department_id) REFERENCES departments(id),
+    FOREIGN KEY (uploaded_by) REFERENCES users(id)
+);

--- a/src/config.php
+++ b/src/config.php
@@ -1,0 +1,20 @@
+<?php
+$host = 'localhost';
+$db   = 'doc_management';
+$user = 'dbuser';
+$pass = 'dbpassword';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $e) {
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
+?>

--- a/src/departments.php
+++ b/src/departments.php
@@ -1,0 +1,26 @@
+<?php
+require 'config.php';
+include 'header.php';
+
+$stmt = $pdo->query('SELECT * FROM departments');
+?>
+<h2>Departamentos</h2>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Nombre</th>
+    </tr>
+  </thead>
+  <tbody>
+<?php while ($row = $stmt->fetch()): ?>
+    <tr>
+      <td><?= htmlspecialchars($row['id']) ?></td>
+      <td><?= htmlspecialchars($row['name']) ?></td>
+    </tr>
+<?php endwhile; ?>
+  </tbody>
+</table>
+<?php
+include 'footer.php';
+?>

--- a/src/documents.php
+++ b/src/documents.php
@@ -1,0 +1,33 @@
+<?php
+require 'config.php';
+include 'header.php';
+
+$query = 'SELECT d.id, d.title, d.filename, dp.name AS department
+          FROM documents d
+          JOIN departments dp ON d.department_id = dp.id';
+$stmt = $pdo->query($query);
+?>
+<h2>Documentos</h2>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Título</th>
+      <th>Archivo</th>
+      <th>Departamento</th>
+    </tr>
+  </thead>
+  <tbody>
+<?php while ($row = $stmt->fetch()): ?>
+    <tr>
+      <td><?= htmlspecialchars($row['id']) ?></td>
+      <td><?= htmlspecialchars($row['title']) ?></td>
+      <td><?= htmlspecialchars($row['filename']) ?></td>
+      <td><?= htmlspecialchars($row['department']) ?></td>
+    </tr>
+<?php endwhile; ?>
+  </tbody>
+</table>
+<?php
+include 'footer.php';
+?>

--- a/src/footer.php
+++ b/src/footer.php
@@ -1,0 +1,4 @@
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/header.php
+++ b/src/header.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gestión Documental</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.php">Gestión Documental</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a class="nav-link" href="departments.php">Departamentos</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="documents.php">Documentos</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container">

--- a/src/index.php
+++ b/src/index.php
@@ -1,0 +1,8 @@
+<?php
+include 'header.php';
+?>
+<h1 class="mb-4">Bienvenido al Sistema de Gestión Documental</h1>
+<p>Utilice el menú para navegar entre departamentos y documentos.</p>
+<?php
+include 'footer.php';
+?>


### PR DESCRIPTION
## Summary
- add a simple PHP example for document management
- include MySQL schema with roles, departments, users and documents
- update README in Spanish with instructions

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869fef648648325ab90a01abb913f4f